### PR TITLE
Alterações no posicionamento da imagem no artigo

### DIFF
--- a/_posts/2019-03-27-trabalhando-com-mixins-no-vuejs.md
+++ b/_posts/2019-03-27-trabalhando-com-mixins-no-vuejs.md
@@ -6,6 +6,8 @@ tags: vue vuejs mixins components
 author: fsenaweb
 ---
 
+Mixins são uma forma flexível de distribuir funcionalidade reutilizável em diversos componentes Vue.
+
 ![](https://cdn-images-1.medium.com/max/800/1*mGLyzR9e51d_DEYWyQ1Hog.jpeg)
 
 Fala galera! 


### PR DESCRIPTION
Segue a alteração. O sistema ler o primeiro parágrafo e o coloca como texto introdutório na listagem dos artigos, como no meu artigo, o primeiro parágrafo era uma imagem, ai ele faz essa distorção! Fiz a alteração, caso ainda preciso, só aceitar o PR. 
Abraços!